### PR TITLE
Add `go generate` check on PR

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -15,19 +15,25 @@
 name: Validate
 on:
   pull_request:
-    paths:
-      - '**.cue'
 jobs:
-  validate:
+  cue-eval:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.23'
+          go-version: '1.24'
       - shell: bash
         run: go install cuelang.org/go/cmd/cue@latest
       - shell: bash
         run: echo "${HOME}/go/bin" >> $GITHUB_PATH
       - shell: bash
         run: cue vet -c=false ./...
+  go-generate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+      - uses: sudoswedenab/sudo-actions/golang-generate@main

--- a/manifests/workloadtemplate_strimzikafka.yaml
+++ b/manifests/workloadtemplate_strimzikafka.yaml
@@ -33,7 +33,7 @@ spec:
       monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
     )
 
-    #Odd:             num={1 + 2*(div(num, 2))}
+    #Odd:             num=1 + 2*(div(num, 2))
     #StorageType:     "ephemeral" | "persistent-claim"
     #StorageClass:    "cephfs" | "rbd"
     #CpuQuantity:     string & =~"^([0-9]+(\\.[0-9]+)?)(m)?$"


### PR DESCRIPTION
Currently we do not check if `go generate` has been run before the
changes have been committed. It is very important that that command has
been run, especially since it is the resulting `.yaml` files that are
pushed to the k8s cluster.

This commit uses a custom reusable workflow to ensure that we have that
check on the PRs.
