### PR TITLE
Use go.mod for go version in gh workflow

### DIFF
--- a/.github/workflows/validate.yaml
+++ b/.github/workflows/validate.yaml
@@ -22,7 +22,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       - shell: bash
         run: go install cuelang.org/go/cmd/cue@latest
       - shell: bash
@@ -35,5 +35,5 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-go@v5
         with:
-          go-version: '1.24'
+          go-version-file: go.mod
       - uses: sudoswedenab/sudo-actions/golang-generate@main


### PR DESCRIPTION
Currently the validation GH workflow uses a statically defined golang
verion.

This commit changes the behaviour to use go.mod as source of truth for
the golang version.
