### PR TITLE
update helm-chart to include valuesFrom functionality

### DIFF
--- a/manifests/workloadtemplate_helmchart.yaml
+++ b/manifests/workloadtemplate_helmchart.yaml
@@ -30,6 +30,7 @@ spec:
       repository!: =~"^(http?s|oci)://.*$"
       version!:    string
       values?: [string]: _
+      valuesFrom?: [...VALUESREFERENCE.#x]
       namespaceLabels: {
         [key=string]: string
       } | *{}
@@ -183,6 +184,21 @@ spec:
         {
           values: #workload.spec.input.values
         }
+        if #workload.spec.input.valuesFrom != _|_ // explicit error (_|_ literal) in source
+        {
+          valuesFrom: #workload.spec.input.valuesFrom
+        }
+      }
+    }
+
+    //cue:path: "github.com/fluxcd/helm-controller/api/v2".#ValuesReference
+    let VALUESREFERENCE = {
+      #x: {
+        kind:        string @go(Kind)
+        name:        string @go(Name)
+        valuesKey?:  string @go(ValuesKey)
+        targetPath?: string @go(TargetPath)
+        optional?:   bool   @go(Optional)
       }
     }
 
@@ -1243,17 +1259,6 @@ spec:
         keepHistory?:         bool               @go(KeepHistory)
         disableWait?:         bool               @go(DisableWait)
         deletionPropagation?: null | string      @go(DeletionPropagation,*string)
-      }
-    }
-
-    //cue:path: "github.com/fluxcd/helm-controller/api/v2".#ValuesReference
-    let VALUESREFERENCE = {
-      #x: {
-        kind:        string @go(Kind)
-        name:        string @go(Name)
-        valuesKey?:  string @go(ValuesKey)
-        targetPath?: string @go(TargetPath)
-        optional?:   bool   @go(Optional)
       }
     }
 

--- a/templates/helm-chart/helm-chart.cue
+++ b/templates/helm-chart/helm-chart.cue
@@ -17,6 +17,7 @@ import (
 	repository!: string & =~"^(http?s|oci)://.*$"
 	version!:    string
 	values?: [string]: _
+	valuesFrom?: [...helmv2.#ValuesReference]
 	namespaceLabels: {[key=string]: string} | *{}
 
 	// Extra manifests to apply in the same workload (e.g. SealedSecret,
@@ -137,6 +138,9 @@ helmRelease: helmv2.#HelmRelease & {
 		targetNamespace:  #workload.spec.targetNamespace
 		if #workload.spec.input.values != _|_ {
 			values: #workload.spec.input.values
+		}
+		if #workload.spec.input.valuesFrom != _|_ {
+			valuesFrom: #workload.spec.input.valuesFrom
 		}
 	}
 }


### PR DESCRIPTION
there are many chart out there that don't support loading variable from
(for example) secrets. This means that in certain cases Workload objects
must contain raw secrets. This commit allows loading those from objects
instead.

Further work (most likely on the workload reconciler) will need to be
done to restrict this properly to org namespace and objects
labeled/annotated with workload-specific information
